### PR TITLE
Backport go-starter fixes

### DIFF
--- a/.github/actions/rubocop-formula/action.yml
+++ b/.github/actions/rubocop-formula/action.yml
@@ -12,6 +12,9 @@ runs:
         GH_TOKEN: ${{ github.token }}
       run: |
         ./pkgs/render.sh brew
+    - name: Output name with underscores
+      id: underscore
+      uses: ./.github/actions/underscore-name
     - uses: anttiharju/actions/rubocop-file@v0
       with:
-        file: "pkgs/brew/${{ github.event.repository.name }}.rb"
+        file: "pkgs/brew/${{ steps.underscore.outputs.filename }}.rb"

--- a/.github/actions/underscore-name/action.yml
+++ b/.github/actions/underscore-name/action.yml
@@ -1,0 +1,17 @@
+name: "Underscore name"
+description: "Output repository name with underscores instead of hyphens"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Convert hyphens to underscores
+      id: file
+      shell: bash
+      env:
+        REPO_NAME: ${{ github.event.repository.name }}
+      run: |
+        echo "name=${REPO_NAME//-/_}" >> "$GITHUB_OUTPUT"
+outputs:
+  filename:
+    description: "Filename with underscores"
+    value: ${{ steps.file.outputs.name }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -33,6 +33,16 @@ jobs:
           repository: anttiharju/homebrew-tap
           token: ${{ steps.generate-token.outputs.token }}
           path: homebrew-tap
+      - name: Convert hyphens to underscores
+        id: file
+        shell: bash
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          echo "name=${REPO_NAME//-/_}" >> "$GITHUB_OUTPUT"
+      - name: Output name with underscores
+        id: underscore
+        uses: ./.github/actions/underscore-name
       - name: Render template
         env:
           TAG: ${{ inputs.tag }}
@@ -40,7 +50,7 @@ jobs:
         with:
           template: pkgs/brew/template.rb
           values: pkgs/brew/values.sh
-          output: homebrew-tap/Formula/${{ github.event.repository.name }}.rb
+          output: homebrew-tap/Formula/${{ steps.underscore.outputs.filename }}.rb
       - name: Commit changes
         uses: anttiharju/actions/commit-changes@v0
         with:

--- a/pkgs/brew/values.sh
+++ b/pkgs/brew/values.sh
@@ -8,7 +8,7 @@ capture() {
 
 repo="$(basename "$GITHUB_REPOSITORY")"
 capture PKG_REPO "$repo"
-class="$(awk 'BEGIN{print toupper(substr("'"$repo"'",1,1)) substr("'"$repo"'",2)}')"
+class="$(echo "$repo" | awk -F'-' '{for(i=1;i<=NF;i++) printf "%s%s", toupper(substr($i,1,1)), substr($i,2)}')"
 capture PKG_CLASS "$class"
 desc="$(gh repo view --json description --jq .description)"
 capture PKG_DESC "$desc"

--- a/pkgs/render.sh
+++ b/pkgs/render.sh
@@ -40,5 +40,6 @@ cd "$pkg"
 # shellcheck disable=SC1091
 source "values.cache"
 repository="${GITHUB_REPOSITORY##*/}"
-envsubst -i "template.$ext" -no-unset -no-empty > "$repository.$ext"
-cp "template.$ext" "$repository.tpl.$ext" # easier to visually diff two gitignored files
+filename="${repository//-/_}"
+envsubst -i "template.$ext" -no-unset -no-empty > "$filename.$ext"
+cp "template.$ext" "$filename.tpl.$ext" # easier to visually diff two gitignored files


### PR DESCRIPTION
This repo did not have a hyphen in its name so it never had to care about these

I plan to improve go-starter and that includes piloting in downstream repos, so getting to parity is important to have upstreaming be easy.