### PR TITLE
Match Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/anttiharju/relcheck
 
-go 1.24.6
+go 1.24.9


### PR DESCRIPTION
Reverted because of relcheck -> vmatch change but forgot the version bump