### PR TITLE
Fix nix template rendering

### DIFF
--- a/.github/actions/release/github/action.yml
+++ b/.github/actions/release/github/action.yml
@@ -48,4 +48,3 @@ runs:
         git push origin "$tag"
         gh release create "$tag" --title="$title" --generate-notes --draft
         find . -maxdepth 1 -name '${{ github.event.repository.name }}-*.tar.gz' -exec gh release upload "$tag" {} \;
-        gh release edit "$tag" --draft=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,15 +38,15 @@ jobs:
           anttiharju-bot-id: ${{ secrets.ANTTIHARJU_BOT_ID }}
           anttiharju-bot-private-key: ${{ secrets.ANTTIHARJU_BOT_PRIVATE_KEY }}
 
-      - name: Nix User Repository
-        uses: ./.github/actions/release/nur-packages
+      - name: GitHub
+        uses: ./.github/actions/release/github
         with:
           version: ${{ needs.plan.outputs.version }}
           anttiharju-bot-id: ${{ secrets.ANTTIHARJU_BOT_ID }}
           anttiharju-bot-private-key: ${{ secrets.ANTTIHARJU_BOT_PRIVATE_KEY }}
 
-      - name: GitHub
-        uses: ./.github/actions/release/github
+      - name: Nix User Repository
+        uses: ./.github/actions/release/nur-packages
         with:
           version: ${{ needs.plan.outputs.version }}
           anttiharju-bot-id: ${{ secrets.ANTTIHARJU_BOT_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,10 @@ jobs:
         with:
           anttiharju-bot-id: ${{ secrets.ANTTIHARJU_BOT_ID }}
           anttiharju-bot-private-key: ${{ secrets.ANTTIHARJU_BOT_PRIVATE_KEY }}
+
+      - name: Lock release immutability
+        shell: sh
+        env:
+          tag: "v${{ needs.plan.outputs.version }}"
+        run: |
+          gh release edit "$tag" --draft=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,12 +32,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Documentation
-        uses: ./.github/actions/release/documentation
-        with:
-          anttiharju-bot-id: ${{ secrets.ANTTIHARJU_BOT_ID }}
-          anttiharju-bot-private-key: ${{ secrets.ANTTIHARJU_BOT_PRIVATE_KEY }}
-
       - name: GitHub
         uses: ./.github/actions/release/github
         with:
@@ -56,5 +50,11 @@ jobs:
         uses: ./.github/actions/release/homebrew-tap
         with:
           version: ${{ needs.plan.outputs.version }}
+          anttiharju-bot-id: ${{ secrets.ANTTIHARJU_BOT_ID }}
+          anttiharju-bot-private-key: ${{ secrets.ANTTIHARJU_BOT_PRIVATE_KEY }}
+
+      - name: Documentation
+        uses: ./.github/actions/release/documentation
+        with:
           anttiharju-bot-id: ${{ secrets.ANTTIHARJU_BOT_ID }}
           anttiharju-bot-private-key: ${{ secrets.ANTTIHARJU_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
It was rendering version as 0.0.0, because the tag is created by the github release step running after it. Now GitHub step runs first.

Also immutability is only locked as the very last step, allowing for failures in release steps.